### PR TITLE
feat: add allowDeclareFields for babel ts option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ function vue2JsxPlugin(options: Options = {}): Plugin {
       // use id for script blocks in Vue SFCs (e.g. `App.vue?vue&type=script&lang.jsx`)
       // use filepath for plain jsx files (e.g. App.jsx)
       if (filter(id) || filter(filepath)) {
-        const plugins = [importMeta, ...babelPlugins]
+        const plugins = [importMeta]
         const presets = [
           [jsx, {
             compositionAPI: 'native',
@@ -113,7 +113,8 @@ function vue2JsxPlugin(options: Options = {}): Plugin {
             { isTSX: true, allowExtensions: true, allowDeclareFields: true }
           ])
         }
-
+        // custom babel plugins should put *after* ts plugin
+        plugins.push(...babelPlugins)
         const result = babel.transformSync(code, {
           babelrc: false,
           ast: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ function vue2JsxPlugin(options: Options = {}): Plugin {
               (r) => r.default
             ),
             // @ts-ignore
-            { isTSX: true, allowExtensions: true }
+            { isTSX: true, allowExtensions: true, allowDeclareFields: true }
           ])
         }
 


### PR DESCRIPTION
Allow using `declare` in `vue-class-component`

```js
@Component
export default class HelloWorld extends Vue {
  // non-reactive
  declare foo: number;
}
```

related https://github.com/underfin/vite-plugin-vue2/pull/120